### PR TITLE
bump element-class@0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "defaultcss": "^1.1.0",
     "docker-browser-console": "^4.3.0",
     "edit": "^1.0.0",
-    "element-class": "^0.1.1",
+    "element-class": "^0.2.2",
     "flatui": "^1.0.0",
     "gh-pages-deploy": "^0.1.1",
     "iframe": "^0.3.0",


### PR DESCRIPTION
You've [added the code to toggle the editor](commit/bc8c7a60adddb13bc522e278e461a0d03057b850), but `element-class` is pegged at `0.1.x` and the `.toggle` method wasn't added until [0.2.1](https://github.com/maxogden/element-class/compare/v0.2.0...v0.2.1).

Happy to go this route or change to using the tilde operator. Whichever you prefer. :grinning:
